### PR TITLE
Fix undefined decimal sign issue

### DIFF
--- a/js/missionSupport.js
+++ b/js/missionSupport.js
@@ -463,7 +463,7 @@ function updateMissions(diff){
         data.bestMoney = data.bestMoney.max(data.money)
 
         if (isNaN(data.money.mag)) {
-                Decimal(0)
+                data.money = new Decimal(0)
                 console.log(player)
                 console.log(data.money)
         }

--- a/js/utils.js
+++ b/js/utils.js
@@ -47,7 +47,7 @@ function format(decimal, precision=2,) {
 	if (isNaN(decimal.sign)||isNaN(decimal.layer)||isNaN(decimal.mag)) {
 		player.hasNaN = true;
 		console.log(decimal)
-		Decimal(0)
+		// Decimal(0)
 		for (i in player){
 			if (player[i] == undefined) continue
 			if (player[i].points != undefined) {


### PR DESCRIPTION
Noticed the game was completely crashing on load when hitting `missionSupport#updateMissions` and `utils#format`, whenever `Decimal(0)` was called, even well before Missions are unlocked. Some research showed that function constructors require being both prepended by a `new` and to have a context to save to (aka a variable). Adding that to `missionSupport.js` fixed the issue with money starting at NaN. Since the `Decimal(0)` in `utils.js` is completely useless (even if `decimal` were set to 0, the return value is "NaN" and `decimal` is ignored from that point forward) I just removed that line.